### PR TITLE
Add GitHub Action to test CTV formatting

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,21 @@
+name: Check Task View
+on:
+  push:
+    paths:
+      - 'ReproducibleResearch.md'
+  pull_request:
+    paths:
+      - 'ReproducibleResearch.md'
+  workflow_dispatch:
+jobs:
+  check:
+    runs-on: ubuntu-22.04
+    name: Check Task View
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup r2u
+        run: sudo bash ci/setup-r2u.sh
+      - name: Install dependencies
+        run: sudo bash ci/install-dependencies.sh
+      - name: Check Task View
+        run: Rscript ci/check.R

--- a/ci/check.R
+++ b/ci/check.R
@@ -1,0 +1,9 @@
+#!/usr/bin/env Rscript
+
+library("ctv")
+
+f <- "ReproducibleResearch.md"
+
+read.ctv(f)
+ctv2html(f)
+check_ctv_packages(f)

--- a/ci/install-dependencies.sh
+++ b/ci/install-dependencies.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eu
+
+# Install dependencies with APT/r2u
+
+apt-get install --yes \
+  pandoc \
+  r-cran-ctv \
+  r-cran-knitr \
+  r-cran-rmarkdown \
+  r-cran-xml2

--- a/ci/setup-r2u.sh
+++ b/ci/setup-r2u.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eu
+
+# Setup r2u to install CRAN packages as Ubuntu binaries via APT
+#
+# https://github.com/eddelbuettel/r2u
+# https://github.com/eddelbuettel/r2u/blob/master/inst/scripts/add_cranapt_jammy.sh
+
+apt-get update
+apt-get install --yes --no-install-recommends wget ca-certificates
+wget -q -O- https://eddelbuettel.github.io/r2u/assets/dirk_eddelbuettel_key.asc \
+  | tee -a /etc/apt/trusted.gpg.d/cranapt_key.asc
+echo "deb [arch=amd64] https://r2u.stat.illinois.edu/ubuntu jammy main" \
+  > /etc/apt/sources.list.d/cranapt.list
+apt-get update
+wget -q -O- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc \
+  | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc
+echo "deb [arch=amd64] https://cloud.r-project.org/bin/linux/ubuntu jammy-cran40/" \
+  > /etc/apt/sources.list.d/cran_r.list
+echo "Package: *" > /etc/apt/preferences.d/99cranapt
+echo "Pin: release o=CRAN-Apt Project" >> /etc/apt/preferences.d/99cranapt
+echo "Pin: release l=CRAN-Apt Packages" >> /etc/apt/preferences.d/99cranapt
+echo "Pin-Priority: 700"  >> /etc/apt/preferences.d/99cranapt


### PR DESCRIPTION
I assume it's ok to add GitHub Actions to automatically check the CTV formatting

Currently it simply makes sure it can read and convert it, plus prints the results of `check_ctv_packages()`. In the future we could make it more strict based on the results of `check_ctv_packages()`, but that might not make sense it is unlikely that a missing package is due to the current commit/PR