### PR TITLE
Add 'makeit' package

### DIFF
--- a/ReproducibleResearch.md
+++ b/ReproducibleResearch.md
@@ -198,6 +198,9 @@ R-focused.
 - `r pkg("flowr")`: This framework allows you to design
   and implement complex pipelines, and deploy them on your
   institution's computing cluster.
+- `r pkg("makeit")`: Run R scripts if needed, based on last modified
+  time. Implemented in base R with no additional software requirements,
+  organizational overhead, or structural requirements.
 - `r pkg("makepipe")`: A suite of tools for transforming
   an existing workflow into a self-documenting pipeline with very
   minimal upfront costs.


### PR DESCRIPTION
Hi, I've just submitted a new package to CRAN called 'makeit', providing a make() function.

Compared to other make-like packages on CRAN, it's the simplest and most straightforward to use for any existing R scripts.

It's just one function that does one thing, but it does it well :) Should fit well as a an import for project management packages with a specific structure and logic.

I took the liberty of proposing an introductory sentence comparing the make-like packages.

Cheers,
Arni