### PR TITLE
Update 'makeit' description

### DIFF
--- a/ReproducibleResearch.md
+++ b/ReproducibleResearch.md
@@ -203,8 +203,8 @@ R-focused.
   Organize, orchestrate, and monitor multiple pipelines in a single project. Use
   tags to decorate functions with scheduling parameters and configuration.
 - `r pkg("makeit")`: Run R scripts if needed, based on last modified
-  time. Implemented in base R with no additional software requirements,
-  organizational overhead, or structural requirements.
+  time. It comes with no package dependencies, organizational overhead,
+  or structural requirements.
 - `r pkg("makepipe")`: A suite of tools for transforming
   an existing workflow into a self-documenting pipeline with very
   minimal upfront costs.


### PR DESCRIPTION
Hi, this pull request updates the description of the `makeit` package. This brings it up to date with the current package description on CRAN.

The previous emphasis on 'base R' could mislead some to think that it may not align well with their tidyverse programming style. The fact is that `makeit` works equally well with base R and tidyverse style code, so there's no reason to mention either style.

Thanks for maintaining this excellent CRAN task view.